### PR TITLE
SBCodepointSequence: Mark buffer as `const`

### DIFF
--- a/Headers/SBCodepointSequence.h
+++ b/Headers/SBCodepointSequence.h
@@ -29,7 +29,7 @@ typedef SBUInt32 SBStringEncoding;
 
 typedef struct _SBCodepointSequence {
     SBStringEncoding stringEncoding; /**< The encoding of the string. */
-    void *stringBuffer;              /**< The source string containing the code units. */
+    const void *stringBuffer;        /**< The source string containing the code units. */
     SBUInteger stringLength;         /**< The length of the string in terms of code units. */
 } SBCodepointSequence;
 


### PR DESCRIPTION
The functions never modify the buffer.
Marking it as const avoids the need for `const_cast` in C++ (as seen in https://github.com/diasurgical/devilutionX/pull/7698/files#diff-34f5922088a0ad010a634e20bd2e1497d6bf759621eec0e03322f99a8022b06e)

The `const` qualifier was introduced in C89.