### PR TITLE
SBCodepointSequence: Expose functions for known encodings

### DIFF
--- a/Headers/SBCodepoint.h
+++ b/Headers/SBCodepoint.h
@@ -77,4 +77,101 @@ SBCodepoint SBCodepointGetMirror(SBCodepoint codepoint);
  */
 SBScript SBCodepointGetScript(SBCodepoint codepoint);
 
+
+/**
+ * Returns the code point at the given UTF-8 code unit index.
+ *
+ * @param buffer
+ *      The buffer holding the code units.
+ * @param length
+ *      Length of the buffer.
+ * @param stringIndex
+ *      The index of code unit at which to get the code point. On output, it is set to point to the
+ *      first code unit of next code point.
+ * @return
+ *      The code point at the given string index, or SBCodepointInvalid if stringIndex is larger
+ *      than or equal to actual length of source string.
+ */
+SBCodepoint SBCodepointDecodeNextFromUTF8(const SBUInt8 *buffer, SBUInteger length, SBUInteger *stringIndex);
+
+/**
+ * Returns the code point before the given UTF-8 code unit index.
+ *
+ * @param buffer
+ *      The buffer holding the code units.
+ * @param length
+ *      Length of the buffer.
+ * @param stringIndex
+ *      The index of code unit before which to get the code point. On output, it is set to point to
+ *      the first code unit of returned code point.
+ * @return
+ *      The code point before the given string index, or SBCodepointInvalid if stringIndex is equal 
+ *      to zero or larger than actual length of source string.
+ */
+SBCodepoint SBCodepointDecodePreviousFromUTF8(const SBUInt8 *buffer, SBUInteger length, SBUInteger *stringIndex);
+
+/**
+ * Returns the code point at the given UTF-16 code unit index.
+ *
+ * @param buffer
+ *      The buffer holding the code units.
+ * @param length
+ *      Length of the buffer.
+ * @param stringIndex
+ *      The index of code unit at which to get the code point. On output, it is set to point to the
+ *      first code unit of next code point.
+ * @return
+ *      The code point at the given string index, or SBCodepointInvalid if stringIndex is larger
+ *      than or equal to actual length of source string.
+ */
+SBCodepoint SBCodepointDecodeNextFromUTF16(const SBUInt16 *buffer, SBUInteger length, SBUInteger *stringIndex);
+
+/**
+ * Returns the code point before the given UTF-16 code unit index.
+ *
+ * @param buffer
+ *      The buffer holding the code units.
+ * @param length
+ *      Length of the buffer.
+ * @param stringIndex
+ *      The index of code unit before which to get the code point. On output, it is set to point to
+ *      the first code unit of returned code point.
+ * @return
+ *      The code point before the given string index, or SBCodepointInvalid if stringIndex is equal 
+ *      to zero or larger than actual length of source string.
+ */
+SBCodepoint SBCodepointDecodePreviousFromUTF16(const SBUInt16 *buffer, SBUInteger length, SBUInteger *stringIndex);
+
+/**
+ * Returns the code point at the given UTF-32 code unit index.
+ *
+ * @param buffer
+ *      The buffer holding the code units.
+ * @param length
+ *      Length of the buffer.
+ * @param stringIndex
+ *      The index of code unit at which to get the code point. On output, it is set to point to the
+ *      first code unit of next code point.
+ * @return
+ *      The code point at the given string index, or SBCodepointInvalid if stringIndex is larger
+ *      than or equal to actual length of source string.
+ */
+SBCodepoint SBCodepointDecodeNextFromUTF32(const SBUInt32 *buffer, SBUInteger length, SBUInteger *stringIndex);
+
+/**
+ * Returns the code point before the given UTF-32 code unit index.
+ *
+ * @param buffer
+ *      The buffer holding the code units.
+ * @param length
+ *      Length of the buffer.
+ * @param stringIndex
+ *      The index of code unit before which to get the code point. On output, it is set to point to
+ *      the first code unit of returned code point.
+ * @return
+ *      The code point before the given string index, or SBCodepointInvalid if stringIndex is equal 
+ *      to zero or larger than actual length of source string.
+ */
+SBCodepoint SBCodepointDecodePreviousFromUTF32(const SBUInt32 *buffer, SBUInteger length, SBUInteger *stringIndex);
+
 #endif

--- a/Headers/SBCodepoint.h
+++ b/Headers/SBCodepoint.h
@@ -38,6 +38,24 @@ typedef SBUInt32                    SBCodepoint;
 #define SBCodepointFaulty           0xFFFD
 
 /**
+ * Maximum valid code point value.
+ */
+#define SBCodepointMax                      0x10FFFF
+
+/**
+ * Whether the code point value represents part of a UTF-16 surrogate pair.
+ * Such code point values are invalid.
+ */
+#define SBCodepointIsSurrogate(c)           SBUInt32InRange(c, 0xD800, 0xDFFF)
+
+/**
+ * Whether this code point value is valid, i.e.:
+ * 1. It is less than 0x10FFFF.
+ * 2. It is not in the surrogate range (0xD800 to 0xDFFF).
+ */
+#define SBCodepointIsValid(c)               (!SBCodepointIsSurrogate(c) && (c) <= SBCodepointMax)
+
+/**
  * Returns the bidirectional type of a code point.
  *
  * @param codepoint
@@ -141,37 +159,5 @@ SBCodepoint SBCodepointDecodeNextFromUTF16(const SBUInt16 *buffer, SBUInteger le
  *      to zero or larger than actual length of source string.
  */
 SBCodepoint SBCodepointDecodePreviousFromUTF16(const SBUInt16 *buffer, SBUInteger length, SBUInteger *stringIndex);
-
-/**
- * Returns the code point at the given UTF-32 code unit index.
- *
- * @param buffer
- *      The buffer holding the code units.
- * @param length
- *      Length of the buffer.
- * @param stringIndex
- *      The index of code unit at which to get the code point. On output, it is set to point to the
- *      first code unit of next code point.
- * @return
- *      The code point at the given string index, or SBCodepointInvalid if stringIndex is larger
- *      than or equal to actual length of source string.
- */
-SBCodepoint SBCodepointDecodeNextFromUTF32(const SBUInt32 *buffer, SBUInteger length, SBUInteger *stringIndex);
-
-/**
- * Returns the code point before the given UTF-32 code unit index.
- *
- * @param buffer
- *      The buffer holding the code units.
- * @param length
- *      Length of the buffer.
- * @param stringIndex
- *      The index of code unit before which to get the code point. On output, it is set to point to
- *      the first code unit of returned code point.
- * @return
- *      The code point before the given string index, or SBCodepointInvalid if stringIndex is equal 
- *      to zero or larger than actual length of source string.
- */
-SBCodepoint SBCodepointDecodePreviousFromUTF32(const SBUInt32 *buffer, SBUInteger length, SBUInteger *stringIndex);
 
 #endif

--- a/Source/SBBase.c
+++ b/Source/SBBase.c
@@ -418,3 +418,202 @@ SBUInt32 SBScriptGetOpenTypeTag(SBScript script)
         return TAG('D', 'F', 'L', 'T');
     }
 }
+
+typedef struct {
+    SBUInt8 valid;
+    SBUInt8 total;
+    SBUInt8 start;
+    SBUInt8 end;
+} UTF8State;
+
+static const UTF8State UTF8StateTable[9] = {
+    {1,0,0x00,0x00}, {0,0,0x00,0x00}, {1,2,0x80,0xBF}, {1,3,0xA0,0xBF}, {1,3,0x80,0xBF},
+    {1,3,0x80,0x9F}, {1,4,0x90,0xBF}, {1,4,0x80,0xBF}, {1,4,0x80,0x8F}
+};
+
+static const SBUInt8 UTF8LookupTable[256] = {
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+/* LEAD: -- 80..BF -- */
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1,
+/* LEAD: -- C0..C1 -- */
+    1, 1,
+/* LEAD: -- C2..DF -- */
+    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+/* LEAD: -- E0..E0 -- */
+    3,
+/* LEAD: -- E1..EC -- */
+    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+/* LEAD: -- ED..ED -- */
+    5,
+/* LEAD: -- EE..EF -- */
+    4, 4,
+/* LEAD: -- F0..F0 -- */
+    6,
+/* LEAD: -- F1..F3 -- */
+    7, 7, 7,
+/* LEAD: -- F4..F4 -- */
+    8,
+/* LEAD: -- F5..F7 -- */
+    1, 1, 1,
+/* LEAD: -- F8..FB -- */
+    1, 1, 1, 1,
+/* LEAD: -- FC..FD -- */
+    1, 1,
+/* LEAD: -- FE..FF -- */
+    1, 1
+};
+
+SBCodepoint SBCodepointDecodeNextFromUTF8(const SBUInt8 *buffer, SBUInteger length, SBUInteger *index)
+{
+    SBUInt8 lead;
+    UTF8State state;
+    SBUInteger limit;
+    SBCodepoint codepoint;
+
+    lead = buffer[*index];
+    state = UTF8StateTable[UTF8LookupTable[lead]];
+    limit = *index + state.total;
+
+    if (limit > length) {
+        limit = length;
+        state.valid = SBFalse;
+    }
+
+    codepoint = lead & (0x7F >> state.total);
+
+    while (++(*index) < limit) {
+        SBUInt8 byte = buffer[*index];
+
+        if (byte >= state.start && byte <= state.end) {
+            codepoint = (codepoint << 6) | (byte & 0x3F);
+        } else {
+            state.valid = SBFalse;
+            break;
+        }
+
+        state.start = 0x80;
+        state.end = 0xBF;
+    }
+
+    if (state.valid) {
+        return codepoint;
+    }
+
+    return SBCodepointFaulty;
+}
+
+SBCodepoint SBCodepointDecodePreviousFromUTF8(const SBUInt8 *buffer, SBUInteger length, SBUInteger *index)
+{
+    SBUInteger startIndex = *index;
+    SBUInteger limitIndex;
+    SBUInteger continuation;
+    SBCodepoint codepoint;
+
+    continuation = 4;
+
+    while (continuation-- && --startIndex) {
+        SBUInt8 codeunit = buffer[startIndex];
+
+        if ((codeunit & 0xC0) != 0x80) {
+            break;
+        }
+    }
+
+    limitIndex = startIndex;
+    codepoint = SBCodepointDecodeNextFromUTF8(buffer, length, &limitIndex);
+
+    if (limitIndex == *index) {
+        *index = startIndex;
+    } else {
+        codepoint = SBCodepointFaulty;
+        *index -= 1;
+    }
+
+    return codepoint;
+}
+
+SBCodepoint SBCodepointDecodeNextFromUTF16(const SBUInt16 *buffer, SBUInteger length, SBUInteger *index)
+{
+    SBCodepoint codepoint;
+    SBUInt16 lead;
+
+    codepoint = SBCodepointFaulty;
+
+    lead = buffer[*index];
+    *index += 1;
+
+    if (!SBCodepointIsSurrogate(lead)) {
+        codepoint = lead;
+    } else if (lead <= 0xDBFF) {
+        if (*index < length) {
+            SBUInt16 trail = buffer[*index];
+
+            if (SBUInt16InRange(trail, 0xDC00, 0xDFFF)) {
+                codepoint = (lead << 10) + trail - ((0xD800 << 10) + 0xDC00 - 0x10000);
+                *index += 1;
+            }
+        }
+    }
+
+    return codepoint;
+}
+
+SBCodepoint SBCodepointDecodePreviousFromUTF16(const SBUInt16 *buffer, SBUInteger length, SBUInteger *index)
+{
+    SBCodepoint codepoint;
+    SBUInt16 trail;
+
+    codepoint = SBCodepointFaulty;
+
+    *index -= 1;
+    trail = buffer[*index];
+
+    if (!SBCodepointIsSurrogate(trail)) {
+        codepoint = trail;
+    } else if (trail >= 0xDC00) {
+        if (*index > 0) {
+            SBUInt16 lead = buffer[*index - 1];
+
+            if (SBUInt16InRange(lead, 0xD800, 0xDBFF)) {
+                codepoint = (lead << 10) + trail - ((0xD800 << 10) + 0xDC00 - 0x10000);
+                *index -= 1;
+            }
+        }
+    }
+    
+    return codepoint;
+}
+
+SBCodepoint SBCodepointDecodeNextFromUTF32(const SBUInt32 *buffer, SBUInteger length, SBUInteger *index)
+{
+    SBCodepoint codepoint;
+
+    codepoint = buffer[*index];
+    *index += 1;
+
+    if (SBCodepointIsValid(codepoint)) {
+        return codepoint;
+    }
+    
+    return SBCodepointFaulty;
+}
+
+SBCodepoint SBCodepointDecodePreviousFromUTF32(const SBUInt32 *buffer, SBUInteger length, SBUInteger *index)
+{
+    SBCodepoint codepoint;
+
+    *index -= 1;
+    codepoint = buffer[*index];
+
+    if (SBCodepointIsValid(codepoint)) {
+        return codepoint;
+    }
+
+    return SBCodepointFaulty;
+}

--- a/Source/SBBase.c
+++ b/Source/SBBase.c
@@ -589,31 +589,3 @@ SBCodepoint SBCodepointDecodePreviousFromUTF16(const SBUInt16 *buffer, SBUIntege
     
     return codepoint;
 }
-
-SBCodepoint SBCodepointDecodeNextFromUTF32(const SBUInt32 *buffer, SBUInteger length, SBUInteger *index)
-{
-    SBCodepoint codepoint;
-
-    codepoint = buffer[*index];
-    *index += 1;
-
-    if (SBCodepointIsValid(codepoint)) {
-        return codepoint;
-    }
-    
-    return SBCodepointFaulty;
-}
-
-SBCodepoint SBCodepointDecodePreviousFromUTF32(const SBUInt32 *buffer, SBUInteger length, SBUInteger *index)
-{
-    SBCodepoint codepoint;
-
-    *index -= 1;
-    codepoint = buffer[*index];
-
-    if (SBCodepointIsValid(codepoint)) {
-        return codepoint;
-    }
-
-    return SBCodepointFaulty;
-}

--- a/Source/SBBase.h
+++ b/Source/SBBase.h
@@ -96,13 +96,6 @@ SB_INTERNAL SBBoolean SBUIntegerVerifyRange(SBUInteger actualLength,
 #define SBBidiTypeIsIsolateTerminator(t)    SBBidiTypeIsEqual(t, SBBidiTypePDI)
 #define SBBidiTypeIsNeutralOrIsolate(t)     SBUInt8InRange(t, SBBidiTypeWS, SBBidiTypePDI)
 
-
-#define SBCodepointMax                      0x10FFFF
-#define SBCodepointInRange(v, s, e)         SBUInt32InRange(v, s, e)
-#define SBCodepointIsSurrogate(c)           SBCodepointInRange(c, 0xD800, 0xDFFF)
-#define SBCodepointIsValid(c)               (!SBCodepointIsSurrogate(c) && (c) <= SBCodepointMax)
-
-
 #define SBScriptIsCommonOrInherited(s)      ((s) <= SBScriptZYYY)
 
 #endif

--- a/Source/SBCodepointSequence.c
+++ b/Source/SBCodepointSequence.c
@@ -191,9 +191,9 @@ static SBCodepoint GetUTF8CodepointBefore(const SBUInt8 *buffer, SBUInteger leng
     SBUInteger continuation;
     SBCodepoint codepoint;
 
-    continuation = 7;
+    continuation = 4;
 
-    while (--continuation && --startIndex) {
+    while (continuation-- && --startIndex) {
         SBUInt8 codeunit = buffer[startIndex];
 
         if ((codeunit & 0xC0) != 0x80) {

--- a/Source/SBCodepointSequence.c
+++ b/Source/SBCodepointSequence.c
@@ -23,63 +23,6 @@
 #include "SBBase.h"
 #include "SBCodepointSequence.h"
 
-typedef struct {
-    SBUInt8 valid;
-    SBUInt8 total;
-    SBUInt8 start;
-    SBUInt8 end;
-} UTF8State;
-
-static const UTF8State UTF8StateTable[9] = {
-    {1,0,0x00,0x00}, {0,0,0x00,0x00}, {1,2,0x80,0xBF}, {1,3,0xA0,0xBF}, {1,3,0x80,0xBF},
-    {1,3,0x80,0x9F}, {1,4,0x90,0xBF}, {1,4,0x80,0xBF}, {1,4,0x80,0x8F}
-};
-
-static const SBUInt8 UTF8LookupTable[256] = {
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0,
-/* LEAD: -- 80..BF -- */
-    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1,
-/* LEAD: -- C0..C1 -- */
-    1, 1,
-/* LEAD: -- C2..DF -- */
-    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-/* LEAD: -- E0..E0 -- */
-    3,
-/* LEAD: -- E1..EC -- */
-    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-/* LEAD: -- ED..ED -- */
-    5,
-/* LEAD: -- EE..EF -- */
-    4, 4,
-/* LEAD: -- F0..F0 -- */
-    6,
-/* LEAD: -- F1..F3 -- */
-    7, 7, 7,
-/* LEAD: -- F4..F4 -- */
-    8,
-/* LEAD: -- F5..F7 -- */
-    1, 1, 1,
-/* LEAD: -- F8..FB -- */
-    1, 1, 1, 1,
-/* LEAD: -- FC..FD -- */
-    1, 1,
-/* LEAD: -- FE..FF -- */
-    1, 1
-};
-
-static SBCodepoint GetUTF8CodepointAt(const SBUInt8 *buffer, SBUInteger length, SBUInteger *stringIndex);
-static SBCodepoint GetUTF8CodepointBefore(const SBUInt8 *buffer, SBUInteger length, SBUInteger *stringIndex);
-static SBCodepoint GetUTF16CodepointAt(const SBUInt16 *buffer, SBUInteger length, SBUInteger *stringIndex);
-static SBCodepoint GetUTF16CodepointBefore(const SBUInt16 *buffer, SBUInteger length, SBUInteger *stringIndex);
-static SBCodepoint GetUTF32CodepointAt(const SBUInt32 *buffer, SBUInteger length, SBUInteger *stringIndex);
-static SBCodepoint GetUTF32CodepointBefore(const SBUInt32 *buffer, SBUInteger length, SBUInteger *stringIndex);
-
 SB_INTERNAL SBBoolean SBCodepointSequenceIsValid(const SBCodepointSequence *codepointSequence)
 {
     if (codepointSequence) {
@@ -106,15 +49,15 @@ SBCodepoint SBCodepointSequenceGetCodepointBefore(const SBCodepointSequence *cod
     if ((*stringIndex - 1) < codepointSequence->stringLength) {
         switch (codepointSequence->stringEncoding) {
         case SBStringEncodingUTF8:
-            codepoint = GetUTF8CodepointBefore(codepointSequence->stringBuffer, codepointSequence->stringLength, stringIndex);
+            codepoint = SBCodepointDecodePreviousFromUTF8(codepointSequence->stringBuffer, codepointSequence->stringLength, stringIndex);
             break;
 
         case SBStringEncodingUTF16:
-            codepoint = GetUTF16CodepointBefore(codepointSequence->stringBuffer, codepointSequence->stringLength, stringIndex);
+            codepoint = SBCodepointDecodePreviousFromUTF16(codepointSequence->stringBuffer, codepointSequence->stringLength, stringIndex);
             break;
 
         case SBStringEncodingUTF32:
-            codepoint = GetUTF32CodepointBefore(codepointSequence->stringBuffer, codepointSequence->stringLength, stringIndex);
+            codepoint = SBCodepointDecodePreviousFromUTF32(codepointSequence->stringBuffer, codepointSequence->stringLength, stringIndex);
             break;
         }
     }
@@ -129,167 +72,18 @@ SBCodepoint SBCodepointSequenceGetCodepointAt(const SBCodepointSequence *codepoi
     if (*stringIndex < codepointSequence->stringLength) {
         switch (codepointSequence->stringEncoding) {
         case SBStringEncodingUTF8:
-            codepoint = GetUTF8CodepointAt(codepointSequence->stringBuffer, codepointSequence->stringLength, stringIndex);
+            codepoint = SBCodepointDecodeNextFromUTF8(codepointSequence->stringBuffer, codepointSequence->stringLength, stringIndex);
             break;
 
         case SBStringEncodingUTF16:
-            codepoint = GetUTF16CodepointAt(codepointSequence->stringBuffer, codepointSequence->stringLength, stringIndex);
+            codepoint = SBCodepointDecodeNextFromUTF16(codepointSequence->stringBuffer, codepointSequence->stringLength, stringIndex);
             break;
 
         case SBStringEncodingUTF32:
-            codepoint = GetUTF32CodepointAt(codepointSequence->stringBuffer, codepointSequence->stringLength, stringIndex);
+            codepoint = SBCodepointDecodeNextFromUTF32(codepointSequence->stringBuffer, codepointSequence->stringLength, stringIndex);
             break;
         }
     }
 
     return codepoint;
-}
-
-static SBCodepoint GetUTF8CodepointAt(const SBUInt8 *buffer, SBUInteger length, SBUInteger *index)
-{
-    SBUInt8 lead;
-    UTF8State state;
-    SBUInteger limit;
-    SBCodepoint codepoint;
-
-    lead = buffer[*index];
-    state = UTF8StateTable[UTF8LookupTable[lead]];
-    limit = *index + state.total;
-
-    if (limit > length) {
-        limit = length;
-        state.valid = SBFalse;
-    }
-
-    codepoint = lead & (0x7F >> state.total);
-
-    while (++(*index) < limit) {
-        SBUInt8 byte = buffer[*index];
-
-        if (byte >= state.start && byte <= state.end) {
-            codepoint = (codepoint << 6) | (byte & 0x3F);
-        } else {
-            state.valid = SBFalse;
-            break;
-        }
-
-        state.start = 0x80;
-        state.end = 0xBF;
-    }
-
-    if (state.valid) {
-        return codepoint;
-    }
-
-    return SBCodepointFaulty;
-}
-
-static SBCodepoint GetUTF8CodepointBefore(const SBUInt8 *buffer, SBUInteger length, SBUInteger *index)
-{
-    SBUInteger startIndex = *index;
-    SBUInteger limitIndex;
-    SBUInteger continuation;
-    SBCodepoint codepoint;
-
-    continuation = 4;
-
-    while (continuation-- && --startIndex) {
-        SBUInt8 codeunit = buffer[startIndex];
-
-        if ((codeunit & 0xC0) != 0x80) {
-            break;
-        }
-    }
-
-    limitIndex = startIndex;
-    codepoint = GetUTF8CodepointAt(buffer, length, &limitIndex);
-
-    if (limitIndex == *index) {
-        *index = startIndex;
-    } else {
-        codepoint = SBCodepointFaulty;
-        *index -= 1;
-    }
-
-    return codepoint;
-}
-
-static SBCodepoint GetUTF16CodepointAt(const SBUInt16 *buffer, SBUInteger length, SBUInteger *index)
-{
-    SBCodepoint codepoint;
-    SBUInt16 lead;
-
-    codepoint = SBCodepointFaulty;
-
-    lead = buffer[*index];
-    *index += 1;
-
-    if (!SBCodepointIsSurrogate(lead)) {
-        codepoint = lead;
-    } else if (lead <= 0xDBFF) {
-        if (*index < length) {
-            SBUInt16 trail = buffer[*index];
-
-            if (SBUInt16InRange(trail, 0xDC00, 0xDFFF)) {
-                codepoint = (lead << 10) + trail - ((0xD800 << 10) + 0xDC00 - 0x10000);
-                *index += 1;
-            }
-        }
-    }
-
-    return codepoint;
-}
-
-static SBCodepoint GetUTF16CodepointBefore(const SBUInt16 *buffer, SBUInteger length, SBUInteger *index)
-{
-    SBCodepoint codepoint;
-    SBUInt16 trail;
-
-    codepoint = SBCodepointFaulty;
-
-    *index -= 1;
-    trail = buffer[*index];
-
-    if (!SBCodepointIsSurrogate(trail)) {
-        codepoint = trail;
-    } else if (trail >= 0xDC00) {
-        if (*index > 0) {
-            SBUInt16 lead = buffer[*index - 1];
-
-            if (SBUInt16InRange(lead, 0xD800, 0xDBFF)) {
-                codepoint = (lead << 10) + trail - ((0xD800 << 10) + 0xDC00 - 0x10000);
-                *index -= 1;
-            }
-        }
-    }
-    
-    return codepoint;
-}
-
-static SBCodepoint GetUTF32CodepointAt(const SBUInt32 *buffer, SBUInteger length, SBUInteger *index)
-{
-    SBCodepoint codepoint;
-
-    codepoint = buffer[*index];
-    *index += 1;
-
-    if (SBCodepointIsValid(codepoint)) {
-        return codepoint;
-    }
-    
-    return SBCodepointFaulty;
-}
-
-static SBCodepoint GetUTF32CodepointBefore(const SBUInt32 *buffer, SBUInteger length, SBUInteger *index)
-{
-    SBCodepoint codepoint;
-
-    *index -= 1;
-    codepoint = buffer[*index];
-
-    if (SBCodepointIsValid(codepoint)) {
-        return codepoint;
-    }
-
-    return SBCodepointFaulty;
 }

--- a/Source/SBCodepointSequence.c
+++ b/Source/SBCodepointSequence.c
@@ -57,7 +57,8 @@ SBCodepoint SBCodepointSequenceGetCodepointBefore(const SBCodepointSequence *cod
             break;
 
         case SBStringEncodingUTF32:
-            codepoint = SBCodepointDecodePreviousFromUTF32(codepointSequence->stringBuffer, codepointSequence->stringLength, stringIndex);
+            codepoint = ((const SBUInt32 *) codepointSequence->stringBuffer)[--(*stringIndex)];
+            if (!SBCodepointIsValid(codepoint)) codepoint = SBCodepointFaulty;
             break;
         }
     }
@@ -80,7 +81,8 @@ SBCodepoint SBCodepointSequenceGetCodepointAt(const SBCodepointSequence *codepoi
             break;
 
         case SBStringEncodingUTF32:
-            codepoint = SBCodepointDecodeNextFromUTF32(codepointSequence->stringBuffer, codepointSequence->stringLength, stringIndex);
+            codepoint = ((const SBUInt32 *) codepointSequence->stringBuffer)[(*stringIndex)++];
+            if (!SBCodepointIsValid(codepoint)) codepoint = SBCodepointFaulty;
             break;
         }
     }

--- a/Source/SBCodepointSequence.c
+++ b/Source/SBCodepointSequence.c
@@ -73,12 +73,12 @@ static const SBUInt8 UTF8LookupTable[256] = {
     1, 1
 };
 
-static SBCodepoint GetUTF8CodepointAt(const SBCodepointSequence *codepointSequence, SBUInteger *stringIndex);
-static SBCodepoint GetUTF8CodepointBefore(const SBCodepointSequence *codepointSequence, SBUInteger *stringIndex);
-static SBCodepoint GetUTF16CodepointAt(const SBCodepointSequence *codepointSequence, SBUInteger *stringIndex);
-static SBCodepoint GetUTF16CodepointBefore(const SBCodepointSequence *codepointSequence, SBUInteger *stringIndex);
-static SBCodepoint GetUTF32CodepointAt(const SBCodepointSequence *codepointSequence, SBUInteger *stringIndex);
-static SBCodepoint GetUTF32CodepointBefore(const SBCodepointSequence *codepointSequence, SBUInteger *stringIndex);
+static SBCodepoint GetUTF8CodepointAt(const SBUInt8 *buffer, SBUInteger length, SBUInteger *stringIndex);
+static SBCodepoint GetUTF8CodepointBefore(const SBUInt8 *buffer, SBUInteger length, SBUInteger *stringIndex);
+static SBCodepoint GetUTF16CodepointAt(const SBUInt16 *buffer, SBUInteger length, SBUInteger *stringIndex);
+static SBCodepoint GetUTF16CodepointBefore(const SBUInt16 *buffer, SBUInteger length, SBUInteger *stringIndex);
+static SBCodepoint GetUTF32CodepointAt(const SBUInt32 *buffer, SBUInteger length, SBUInteger *stringIndex);
+static SBCodepoint GetUTF32CodepointBefore(const SBUInt32 *buffer, SBUInteger length, SBUInteger *stringIndex);
 
 SB_INTERNAL SBBoolean SBCodepointSequenceIsValid(const SBCodepointSequence *codepointSequence)
 {
@@ -106,15 +106,15 @@ SBCodepoint SBCodepointSequenceGetCodepointBefore(const SBCodepointSequence *cod
     if ((*stringIndex - 1) < codepointSequence->stringLength) {
         switch (codepointSequence->stringEncoding) {
         case SBStringEncodingUTF8:
-            codepoint = GetUTF8CodepointBefore(codepointSequence, stringIndex);
+            codepoint = GetUTF8CodepointBefore(codepointSequence->stringBuffer, codepointSequence->stringLength, stringIndex);
             break;
 
         case SBStringEncodingUTF16:
-            codepoint = GetUTF16CodepointBefore(codepointSequence, stringIndex);
+            codepoint = GetUTF16CodepointBefore(codepointSequence->stringBuffer, codepointSequence->stringLength, stringIndex);
             break;
 
         case SBStringEncodingUTF32:
-            codepoint = GetUTF32CodepointBefore(codepointSequence, stringIndex);
+            codepoint = GetUTF32CodepointBefore(codepointSequence->stringBuffer, codepointSequence->stringLength, stringIndex);
             break;
         }
     }
@@ -129,15 +129,15 @@ SBCodepoint SBCodepointSequenceGetCodepointAt(const SBCodepointSequence *codepoi
     if (*stringIndex < codepointSequence->stringLength) {
         switch (codepointSequence->stringEncoding) {
         case SBStringEncodingUTF8:
-            codepoint = GetUTF8CodepointAt(codepointSequence, stringIndex);
+            codepoint = GetUTF8CodepointAt(codepointSequence->stringBuffer, codepointSequence->stringLength, stringIndex);
             break;
 
         case SBStringEncodingUTF16:
-            codepoint = GetUTF16CodepointAt(codepointSequence, stringIndex);
+            codepoint = GetUTF16CodepointAt(codepointSequence->stringBuffer, codepointSequence->stringLength, stringIndex);
             break;
 
         case SBStringEncodingUTF32:
-            codepoint = GetUTF32CodepointAt(codepointSequence, stringIndex);
+            codepoint = GetUTF32CodepointAt(codepointSequence->stringBuffer, codepointSequence->stringLength, stringIndex);
             break;
         }
     }
@@ -145,10 +145,8 @@ SBCodepoint SBCodepointSequenceGetCodepointAt(const SBCodepointSequence *codepoi
     return codepoint;
 }
 
-static SBCodepoint GetUTF8CodepointAt(const SBCodepointSequence *sequence, SBUInteger *index)
+static SBCodepoint GetUTF8CodepointAt(const SBUInt8 *buffer, SBUInteger length, SBUInteger *index)
 {
-    const SBUInt8 *buffer = sequence->stringBuffer;
-    SBUInteger length = sequence->stringLength;
     SBUInt8 lead;
     UTF8State state;
     SBUInteger limit;
@@ -186,9 +184,8 @@ static SBCodepoint GetUTF8CodepointAt(const SBCodepointSequence *sequence, SBUIn
     return SBCodepointFaulty;
 }
 
-static SBCodepoint GetUTF8CodepointBefore(const SBCodepointSequence *sequence, SBUInteger *index)
+static SBCodepoint GetUTF8CodepointBefore(const SBUInt8 *buffer, SBUInteger length, SBUInteger *index)
 {
-    const SBUInt8 *buffer = sequence->stringBuffer;
     SBUInteger startIndex = *index;
     SBUInteger limitIndex;
     SBUInteger continuation;
@@ -205,7 +202,7 @@ static SBCodepoint GetUTF8CodepointBefore(const SBCodepointSequence *sequence, S
     }
 
     limitIndex = startIndex;
-    codepoint = GetUTF8CodepointAt(sequence, &limitIndex);
+    codepoint = GetUTF8CodepointAt(buffer, length, &limitIndex);
 
     if (limitIndex == *index) {
         *index = startIndex;
@@ -217,10 +214,8 @@ static SBCodepoint GetUTF8CodepointBefore(const SBCodepointSequence *sequence, S
     return codepoint;
 }
 
-static SBCodepoint GetUTF16CodepointAt(const SBCodepointSequence *sequence, SBUInteger *index)
+static SBCodepoint GetUTF16CodepointAt(const SBUInt16 *buffer, SBUInteger length, SBUInteger *index)
 {
-    const SBUInt16 *buffer = sequence->stringBuffer;
-    SBUInteger length = sequence->stringLength;
     SBCodepoint codepoint;
     SBUInt16 lead;
 
@@ -245,9 +240,8 @@ static SBCodepoint GetUTF16CodepointAt(const SBCodepointSequence *sequence, SBUI
     return codepoint;
 }
 
-static SBCodepoint GetUTF16CodepointBefore(const SBCodepointSequence *sequence, SBUInteger *index)
+static SBCodepoint GetUTF16CodepointBefore(const SBUInt16 *buffer, SBUInteger length, SBUInteger *index)
 {
-    const SBUInt16 *buffer = sequence->stringBuffer;
     SBCodepoint codepoint;
     SBUInt16 trail;
 
@@ -272,9 +266,8 @@ static SBCodepoint GetUTF16CodepointBefore(const SBCodepointSequence *sequence, 
     return codepoint;
 }
 
-static SBCodepoint GetUTF32CodepointAt(const SBCodepointSequence *sequence, SBUInteger *index)
+static SBCodepoint GetUTF32CodepointAt(const SBUInt32 *buffer, SBUInteger length, SBUInteger *index)
 {
-    const SBUInt32 *buffer = sequence->stringBuffer;
     SBCodepoint codepoint;
 
     codepoint = buffer[*index];
@@ -287,9 +280,8 @@ static SBCodepoint GetUTF32CodepointAt(const SBCodepointSequence *sequence, SBUI
     return SBCodepointFaulty;
 }
 
-static SBCodepoint GetUTF32CodepointBefore(const SBCodepointSequence *sequence, SBUInteger *index)
+static SBCodepoint GetUTF32CodepointBefore(const SBUInt32 *buffer, SBUInteger length, SBUInteger *index)
 {
-    const SBUInt32 *buffer = sequence->stringBuffer;
     SBCodepoint codepoint;
 
     *index -= 1;


### PR DESCRIPTION
`GetUTF*` functions only work with specific encodings, and so should accept the concrete buffer type rather than the generic one.

This PR exposes these functions.

The second commit here also fixes overly long loop length (previously it did up to 6 iterations but UTF-8 code points are at most 4 code units long).