### PR TITLE
CMake: Fix install interface headers path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ endif()
 target_include_directories(sheenbidi
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Headers>
-    $<INSTALL_INTERFACE:include>
+    $<INSTALL_INTERFACE:include/SheenBidi>
   PRIVATE
     Source
 )


### PR DESCRIPTION
Fixes the issue that started with the following commit using the installed version of SheenBidi:

https://github.com/Tehreer/SheenBidi/commit/b7fa978ca5c07e938a76cb7bb360c6db578b283d

```
fatal error: SheenBidi.h: No such file or directory
    9 | #include <SheenBidi.h>
      |          ^~~~~~~~~~~~~
```

The /usr/local/include/SheenBidi was no longer in the include path, causing the error above