### PR TITLE
Update README build directories and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
-## Build generated
-build/
-DerivedData/
+## Build directories for CMake
+/build/
+/build-*/
+
+## Build directory for Meson
+/builddir/
+
+## Generated files
+/DerivedData/
 
 ## Various settings
 *.pbxuser

--- a/README.md
+++ b/README.md
@@ -68,17 +68,17 @@ SheenBidi can be compiled with any C compiler. The recommended approach is to ad
 To build and install SheenBidi using CMake:
 
 ```bash
-cmake -S. -Brelease -DCMAKE_BUILD_TYPE=Release
-cmake --build release
-sudo cmake --install release
+cmake -S. -Bbuild-release -DCMAKE_BUILD_TYPE=Release
+cmake --build build-release
+sudo cmake --install build-release
 ```
 
 For development and testing:
 
 ```bash
-cmake -S. -Bdebug -DSB_CONFIG_UNITY=OFF
-cmake --build debug
-ctest --test-dir debug --output-on-failure
+cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Debug -DSB_CONFIG_UNITY=OFF
+cmake --build build
+ctest --test-dir build --output-on-failure
 ```
 
 In other CMake projects, SheenBidi can be found via `find_package(SheenBidi)`, providing the target `SheenBidi::sheenbidi`. SheenBidi can also be used via `FetchContent`.


### PR DESCRIPTION
Usually, build directories start with "build" rather than being just "debug" and "release"

The development directory for CMake should just be "build" because that plays nicely with IDEs (e.g. VSCode, CLion), which all expect the development build to be in "build" by default.

The debug build type should for CMake should be specified explicitly because [by default](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html) it's an empty string (compiler is invoked with default flags).

Also adds build directories to `.gitignore`, including the meson one.