### PR TITLE
cmake: Generate pkg-config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,7 @@ add_library(sheenbidi
 if(BUILDING_DLL)
   target_compile_definitions(sheenbidi PRIVATE SB_CONFIG_DLL_EXPORT)
   target_compile_definitions(sheenbidi INTERFACE SB_CONFIG_DLL_IMPORT)
+  set(SHEENBIDI_PKGCONFIG_CFLAGS "${SHEENBIDI_PKGCONFIG_CFLAGS} -DSB_CONFIG_DLL_IMPORT")
 endif()
 target_include_directories(sheenbidi
   PUBLIC
@@ -288,4 +289,10 @@ install(
     "${CMAKE_CURRENT_BINARY_DIR}/SheenBidi/SheenBidiConfigVersion.cmake"
   DESTINATION
     ${ConfigPackageLocation}
+)
+
+configure_file(sheenbidi.pc.in ${CMAKE_CURRENT_BINARY_DIR}/sheenbidi.pc @ONLY)
+install(
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/sheenbidi.pc
+  DESTINATION ${LIB_INSTALL_DIR}/pkgconfig
 )

--- a/sheenbidi.pc.in
+++ b/sheenbidi.pc.in
@@ -1,0 +1,9 @@
+libdir=@CMAKE_INSTALL_PREFIX@/@LIB_INSTALL_DIR@
+includedir=@CMAKE_INSTALL_PREFIX@/include/SheenBidi
+
+Name: SheenBidi
+Description: SheenBidi is a lightweight, fast and stable implementation of the Unicode Bidirectional Algorithm.
+Version: @PROJECT_VERSION@
+URL: https://github.com/Tehreer/SheenBidi
+Cflags: -I${includedir}@SHEENBIDI_PKGCONFIG_CFLAGS@
+Libs: -L${libdir} -lsheenbidi


### PR DESCRIPTION
This is useful for installing via CMake while enabling usage without CMake (e.g. for distro packages):

```
$ cat /usr/local/lib/pkgconfig/sheenbidi.pc
libdir=/usr/local/lib
includedir=/usr/local/include/SheenBidi

Name: SheenBidi
Description: SheenBidi is a lightweight, fast and stable implementation of the Unicode Bidirectional Algorithm.
Version: 2.8
URL: https://github.com/Tehreer/SheenBidi
Cflags: -I${includedir}
Libs: -L${libdir} -lsheenbidi
```